### PR TITLE
Handle ldflags when the module library is not installed in a system dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ add_executable(compton-conf
 
 target_link_libraries(compton-conf
   ${QTX_LIBRARIES}
-  ${LIBCONFIG_LIBRARIES}
+  ${LIBCONFIG_LDFLAGS}
 )
 
 install(TARGETS compton-conf RUNTIME DESTINATION bin)


### PR DESCRIPTION
Some OSes use other locations for their libraries.
This adds those locations to the linker flags avoiding missing libraries.